### PR TITLE
Add dependency on 1.0.0 as minimum version of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.5"
+poetry = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 
@@ -21,5 +22,5 @@ python = "^3.5"
 vspoetry = 'vspoetry:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
The `poetry env ...` command didn't show up until the 1.0.0 release of poetry.

Add that version as an explicit dependency.